### PR TITLE
Improved functionality of species filter and mapping

### DIFF
--- a/R/process_data.R
+++ b/R/process_data.R
@@ -76,8 +76,15 @@ site_by_species <- function(data, sparse = FALSE, pres_abs = FALSE) {
 filter_species <- function(data, spp_list, resolve = FALSE, join = FALSE) {
 
   if(isTRUE(resolve)) {
-    spp_list <- TNRS::TNRS(spp_list,
-                           sources = c("wfo", "tropicos", "wcvp"))$Name_matched
+    spp_list_tmp <- TNRS::TNRS(spp_list,
+                           sources = c("wfo", "tropicos", "wcvp"))[,c("Name_submitted", "Accepted_name")]
+    if(nrow(dplyr::filter(spp_list_tmp, Name_submitted != Accepted_name))>0){
+      #Strip x in case of hybrid species
+      spp_list_tmp$Accepted_name <- sub(pattern=" x ", replacement=" ", x=spp_list_tmp$Accepted_name)
+      print("Some submitted species names were resolved as follows:")
+      print(dplyr::filter(spp_list_tmp, Name_submitted != Accepted_name))
+    }
+    spp_list <- spp_list_tmp$Accepted_name
   }
 
   spp_filtered <- dplyr::filter(data$DT, Species %in% spp_list)

--- a/R/visualize_data.R
+++ b/R/visualize_data.R
@@ -46,7 +46,7 @@ map_plots <- function(data, type = "grid", grid_size = 300, extent="world") {
     ggplot2::theme(axis.text = ggplot2::element_blank(),
                    legend.title = ggplot2::element_text(size=12),
                    legend.text = ggplot2::element_text(size=12),
-                   legend.background = ggplot2::element_rect(size=0.1, linetype="solid", colour = 1),
+                   legend.background = ggplot2::element_rect(linewidth=0.1, linetype="solid", colour = 1),
                    legend.key.height = ggplot2::unit(1.1, "cm"),
                    legend.key.width = ggplot2::unit(1.1, "cm"))
 
@@ -114,6 +114,10 @@ map_plots <- function(data, type = "grid", grid_size = 300, extent="world") {
 #'@inheritParams filter_species
 #'@inheritParams map_plots
 #'@param species Species name.
+#' @param extent The extent of the returned map. Can be `world` or `aoi`, if
+#'   the map should be zoomed to the area of interest.
+#'@param resolve If `TRUE` (not the default), resolves species names using
+#'   TNRS.
 #'
 #'@return A map of speices occurrences.
 #'@export
@@ -121,11 +125,14 @@ map_plots <- function(data, type = "grid", grid_size = 300, extent="world") {
 #' @examples
 #' data(greece)
 #' map_species(greece, species = "Fagus sylvatica", extent = "aoi")
-map_species <- function(data, species, extent) {
-  data <- filter_species(data, species)
+map_species <- function(data, species, extent="world", resolve = FALSE) {
+  data <- filter_species(data, species, resolve)
   if(nrow(data$DT) == 0) stop("Species not found")
+  if(length(species)==1){
+    mytitle <- species
+  } else {mytitle <- ("Selected species")}
   map_plots(data, type = "points", extent = extent) +
-    ggplot2::labs(title = species, font.face = "italic") +
+    ggplot2::labs(title = mytitle, font.face = "italic") +
     ggplot2::theme(plot.title = ggplot2::element_text(face = "italic"))
 }
 

--- a/man/map_species.Rd
+++ b/man/map_species.Rd
@@ -4,7 +4,7 @@
 \alias{map_species}
 \title{Map Species Occurrences}
 \usage{
-map_species(data, species, extent)
+map_species(data, species, extent = "world", resolve = FALSE)
 }
 \arguments{
 \item{data}{sPlotOpen data, a named list containing \code{DT} (species composition
@@ -14,6 +14,9 @@ data in long format) and \code{header} (plot-level information).}
 
 \item{extent}{The extent of the returned map. Can be \code{world} or \code{aoi}, if
 the map should be zoomed to the area of interest.}
+
+\item{resolve}{If \code{TRUE} (not the default), resolves species names using
+TNRS.}
 }
 \value{
 A map of speices occurrences.


### PR DESCRIPTION
I made a few changes:
1) the `map_species` function now accepts the arguments 'extent' and 'resolve' (which is transferred to the function `filter_species`
2) Since the `map_species` can accept vectors of more than one species, the title of the resulting graph returns 1) the name of the species, when only one species is submitted, or 2) a generic title when more than 1 species is requested
3) `filter_species` function was returning 'Name_matched' instea of the 'Name_accepted'. The matched name is the name submitted to TNRS after some typo corrections. In case of synonyms, the name_submitted won't match the name in sPlot. I switched to 'Accepted_name' now. I also added some more printed output to tell the user how their submitted names were resolved by TNRS. We can consider exporting the dataframe of submitted and accepted names as output from the function.
